### PR TITLE
Invalid Rails example add code and migrations 

### DIFF
--- a/blog/app/models/article.rb
+++ b/blog/app/models/article.rb
@@ -1,0 +1,2 @@
+class Article < ApplicationRecord
+end

--- a/blog/db/migrate/20200402214406_create_articles.rb
+++ b/blog/db/migrate/20200402214406_create_articles.rb
@@ -1,0 +1,10 @@
+class CreateArticles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.text :text
+
+      t.timestamps
+    end
+  end
+end

--- a/blog/test/fixtures/articles.yml
+++ b/blog/test/fixtures/articles.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  text: MyText
+
+two:
+  title: MyString
+  text: MyText

--- a/blog/test/models/article_test.rb
+++ b/blog/test/models/article_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ArticleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This is an example to demonstrate waveaccounting/migration-check-action#1
It should fail the check because both code and migrations are committed.