### PR TITLE
Valid Rails example add migrations

### DIFF
--- a/blog/db/migrate/20200402214406_create_articles.rb
+++ b/blog/db/migrate/20200402214406_create_articles.rb
@@ -1,0 +1,10 @@
+class CreateArticles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.text :text
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
This is an example to demonstrate waveaccounting/migration-check-action#1
It should pass the check because only migrations are committed.